### PR TITLE
Fix unknown git_user_name variable/method

### DIFF
--- a/lib/gem/release/context/git.rb
+++ b/lib/gem/release/context/git.rb
@@ -26,7 +26,7 @@ module Gem
 
         def user_login
           str = `git config --get github.user`.strip
-          str.empty? ? git_user_name : str
+          str.empty? ? user_name : str
         end
       end
     end


### PR DESCRIPTION
When using the `gem bootstrap` command it resulted in the following error:

```
$ bootstrap --template=travis
Scaffolding gem fox-connect-messages
ERROR:  While executing gem ... (NameError)
    undefined local variable or method `git_user_name' for #<Gem::Release::Context::Git:0x00007ff9cc0bfea0>
```

with the following stack trace (rvm stuff snipped):

```
Exception `NameError' at <snip>/gems/gem-release-2.0.1/lib/gem/release/context/git.rb:29 - undefined local variable or method `git_user_name' for #<Gem::Release::Context::Git:0x00007fa73b3bff58>
ERROR:  While executing gem ... (NameError)
    undefined local variable or method `git_user_name' for #<Gem::Release::Context::Git:0x00007fa73b3bff58>
<snip>/gems/gem-release-2.0.1/lib/gem/release/context/git.rb:29:in `user_login'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/data.rb:41:in `user_login'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/data.rb:53:in `homepage'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/data.rb:17:in `data'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/bootstrap.rb:213:in `data'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/bootstrap.rb:178:in `files'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/bootstrap.rb:174:in `scaffold'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/bootstrap.rb:156:in `block in run'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/base.rb:88:in `block in in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context/paths.rb:25:in `block (2 levels) in in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context/paths.rb:9:in `in_dir'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context/paths.rb:25:in `block in in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context/paths.rb:23:in `each'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context/paths.rb:23:in `in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/context.rb:31:in `in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/base.rb:86:in `in_dirs'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/bootstrap.rb:155:in `run'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/runner.rb:19:in `run_cmd'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/cmds/runner.rb:8:in `run'
	<snip>/gems/gem-release-2.0.1/lib/gem/release/support/gem_command.rb:54:in `execute'
	<snip>/rubygems/command.rb:321:in `invoke_with_build_args'
	<snip>/rubygems/command_manager.rb:176:in `process_args'
	<snip>/rubygems/command_manager.rb:146:in `run'
	<snip>/rubygems/gem_runner.rb:59:in `run'
	<snip>/bin/gem:21:in `<main>'
```

Following the stack trace, it seems that the variable naming was not updated. With the fix 'implemented', the behavior was expected. 